### PR TITLE
Streaming

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,9 +1,22 @@
+import json
+
 from fastapi import FastAPI, Cookie, Response
-from models import UserQuery, Answer
-from services import run_chat_only_pipeline, run_agent_pipeline, lifespan
+from fastapi.responses import StreamingResponse
+
+from models import UserQuery, Answer, StreamChunkEvent, StreamFinalEvent, StreamErrorEvent
+from services import run_chat_only_pipeline, run_agent_pipeline, stream_agent_pipeline, get_agent_answer_from_state, lifespan
 
 
 app = FastAPI(lifespan=lifespan)
+
+def make_stream_error_response(message: str, session_id: str | None = None) -> StreamingResponse:
+    def generate_error_stream():
+        yield StreamErrorEvent(content=message).model_dump_json() + '\n'
+
+    stream_response = StreamingResponse(generate_error_stream(), media_type='application/x-ndjson')
+    if session_id:
+        stream_response.set_cookie(key='kubebot_session_id', value=session_id)
+    return stream_response
 
 @app.post('/ask_simple')
 async def ask_question_simple(response: Response, query: UserQuery, kubebot_session_id: str | None = Cookie(default=None))->Answer | None:
@@ -18,8 +31,34 @@ async def ask_question_simple(response: Response, query: UserQuery, kubebot_sess
     response.set_cookie(key='kubebot_session_id',value=returned_session_id)
     return answer
 
-@app.post('/ask')
-async def ask_question(response: Response, query: UserQuery, kubebot_session_id: str | None = Cookie(default=None))->Answer | None:
+@app.post('/ask', response_model=None)
+async def ask_question(response: Response, query: UserQuery, kubebot_session_id: str | None = Cookie(default=None))->Answer | StreamingResponse | None:
+    if query.streaming:
+        returned_session_id = kubebot_session_id
+
+        try:
+            chunk_stream, returned_session_id = stream_agent_pipeline(query, kubebot_session_id)
+        except Exception:
+            return make_stream_error_response('Sorry, I hit a snag and couldn\'t answer your question.', returned_session_id)
+
+        def generate_stream():
+            try:
+                for chunk in chunk_stream:
+                    yield StreamChunkEvent(content=chunk).model_dump_json() + '\n'
+
+                answer = get_agent_answer_from_state(returned_session_id)
+                if answer is None:
+                    yield StreamErrorEvent(content='Sorry, I hit a snag and couldn\'t answer your question.').model_dump_json() + '\n'
+                    return
+
+                yield StreamFinalEvent(answer=answer).model_dump_json() + '\n'
+            except Exception:
+                yield StreamErrorEvent(content='Sorry, I hit a snag and couldn\'t answer your question.').model_dump_json() + '\n'
+
+        stream_response = StreamingResponse(generate_stream(), media_type='application/x-ndjson')
+        stream_response.set_cookie(key='kubebot_session_id', value=returned_session_id)
+        return stream_response
+
     answer: Answer | None = None
     returned_session_id:str = ''
     try:

--- a/backend/models/StreamEvent.py
+++ b/backend/models/StreamEvent.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .Answer import Answer
+
+
+class StreamChunkEvent(BaseModel):
+    type: Literal['chunk'] = 'chunk'
+    content: str
+
+
+class StreamFinalEvent(BaseModel):
+    type: Literal['final'] = 'final'
+    answer: Answer
+
+
+class StreamErrorEvent(BaseModel):
+    type: Literal['error'] = 'error'
+    content: str

--- a/backend/models/UserQuery.py
+++ b/backend/models/UserQuery.py
@@ -2,3 +2,4 @@ from pydantic import BaseModel
 
 class UserQuery(BaseModel):
     question: str
+    streaming: bool = False

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,4 @@
 from .UserQuery import UserQuery
 from .Answer import Answer
 from .Source import Source
+from .StreamEvent import StreamChunkEvent, StreamFinalEvent, StreamErrorEvent

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,2 +1,2 @@
-from .chat import run_chat_only_pipeline, run_agent_pipeline
+from .chat import run_chat_only_pipeline, run_agent_pipeline, stream_agent_pipeline, get_agent_answer_from_state
 from .lifecycle import lifespan

--- a/backend/services/chat.py
+++ b/backend/services/chat.py
@@ -1,8 +1,10 @@
-from typing import TYPE_CHECKING, Iterable, TypeVar, get_origin, get_args
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Iterable, TypeVar, get_origin, get_args
 from models import UserQuery, Source, Answer
 from langchain.messages import AIMessage, ToolMessage
 from langchain.chat_models import init_chat_model
 from langchain.agents import create_agent
+from langchain_core.runnables import RunnableConfig
 from .db import search_db, map_source
 from .memory import generate_session_id
 from prompts import make_grounding_prompt, make_agent_prompt
@@ -130,21 +132,100 @@ def extract_ai_response(response: dict) -> str | None:
     last_ai = get_last_ai_message(messages)
     return last_ai.text if last_ai else None
 
+def build_agent_input(query: UserQuery) -> dict[str, list[dict[str, str]]]:
+    user_prompt: str = make_agent_prompt(query, tools)
+    return {
+        'messages': [
+            {'role': 'user', 'content': user_prompt}
+        ]
+    }
+
+def build_agent_config(session_id: str) -> RunnableConfig:
+    return {'configurable': {'thread_id': session_id}}
+
+def extract_stream_chunk_text(stream_part: Any) -> str:
+    if stream_part.get('type') != 'messages':
+        return ''
+
+    data = stream_part.get('data')
+    if not isinstance(data, tuple) or len(data) != 2:
+        return ''
+
+    message, metadata = data
+    if not isinstance(metadata, dict):
+        return ''
+
+    if metadata.get('langgraph_node') != 'model':
+        return ''
+
+    if getattr(message, 'type', None) == 'tool':
+        return ''
+
+    if getattr(message, 'tool_calls', None):
+        return ''
+
+    content = getattr(message, 'content', None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return ''.join(
+            item.get('text', '')
+            for item in content
+            if isinstance(item, dict) and item.get('type') == 'text'
+        )
+
+    chunk_text = getattr(message, 'text', None)
+    if isinstance(chunk_text, str):
+        return chunk_text
+
+    return ''
+
+def stream_agent_pipeline(query: UserQuery, session_id: str | None) -> tuple[Iterator[str], str]:
+    if not session_id:
+        session_id = generate_session_id()
+
+    assert agent is not None, "Agents not initialized. Call init_agents() first."
+
+    config = build_agent_config(session_id)
+    inputs = build_agent_input(query)
+
+    def event_stream() -> Iterator[str]:
+        assert agent is not None, "Agents not initialized. Call init_agents() first."
+        for stream_part in agent.stream(
+            inputs,
+            config=config,
+            stream_mode='messages',
+            version='v2',
+        ):
+            chunk_text = extract_stream_chunk_text(stream_part)
+            if chunk_text:
+                yield chunk_text
+
+    return event_stream(), session_id
+
+def get_agent_answer_from_state(session_id: str) -> Answer | None:
+    assert agent is not None, "Agents not initialized. Call init_agents() first."
+
+    state = agent.get_state(build_agent_config(session_id))
+    values = state.values
+    if not isinstance(values, dict):
+        return None
+
+    answer_text = extract_ai_response(values)
+    if not answer_text:
+        return None
+
+    return Answer(answer=answer_text, sources=collect_sources(values))
+
 def run_agent_pipeline(query: UserQuery, session_id: str | None)->tuple[Answer | None, str]:
     if not session_id:
         session_id = generate_session_id()
 
     assert agent is not None, "Agents not initialized. Call init_agents() first."
-    
-    user_prompt: str = make_agent_prompt(query, tools)
 
     response = agent.invoke(
-        {'messages':
-            [
-                {'role':'user', 'content': user_prompt}
-            ]
-        },
-        config = {'configurable':{'thread_id': session_id}}
+        build_agent_input(query),
+        config=build_agent_config(session_id)
     )
     
     answer_text = extract_ai_response(response)

--- a/interfaces/tui/kubebot_tui.py
+++ b/interfaces/tui/kubebot_tui.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import asyncio
+import json
 from typing import Dict
 
 try:
@@ -79,6 +81,8 @@ class KubebotApp(App):
 
     CSS_PATH = "tui.tcss"
     BASE_URL = 'http://localhost:8000'
+    STREAM_REVEAL_INTERVAL_SECONDS = 0.02
+    STREAM_REVEAL_CHARS_PER_TICK = 1
     BINDINGS = [
         Binding('up','move_up','Move Up'),
         Binding('down','move_down','Move Down'),
@@ -135,6 +139,34 @@ class KubebotApp(App):
         self.qas.update(self.qa_markdown[self.qa_list_pos])
         self.sources.update(self.sources_markdown[self.qa_list_pos])
 
+    def update_streamed_answer(self, query: str, answer: str) -> None:
+        self.qa_list[self.qa_list_pos][1] = answer
+        self.qa_markdown[self.qa_list_pos] = f'## You:\n{query}\n\n## KubeBot:\n{answer}'
+        self.panes_refresh()
+
+    def take_stream_reveal_chunk(self, pending_text: str) -> tuple[str, str]:
+        if len(pending_text) <= self.STREAM_REVEAL_CHARS_PER_TICK:
+            return pending_text, ''
+
+        split_at = self.STREAM_REVEAL_CHARS_PER_TICK
+        return pending_text[:split_at], pending_text[split_at:]
+
+    async def pump_streamed_markdown(
+        self,
+        markdown_stream,
+        streamed_answer_parts: list[str],
+        pending_text: list[str],
+        stream_complete: list[bool],
+    ) -> None:
+        while pending_text[0] or not stream_complete[0]:
+            if pending_text[0]:
+                next_chunk, remaining_text = self.take_stream_reveal_chunk(pending_text[0])
+                pending_text[0] = remaining_text
+                streamed_answer_parts.append(next_chunk)
+                await markdown_stream.write(next_chunk)
+
+            await asyncio.sleep(self.STREAM_REVEAL_INTERVAL_SECONDS)
+
     @on(Input.Submitted)
     async def on_input(self, event: Input.Submitted) -> None:
         """A coroutine to handle a user query."""
@@ -145,20 +177,67 @@ class KubebotApp(App):
     @work(exclusive=True)
     async def handle_query(self, query:str)->None:
         self.loading_indicator.display = True
+        self.add_qa(query, "")
+        self.add_sources([])
+        self.qas.update(f'## You:\n{query}\n\n## KubeBot:\n')
+        self.sources.update(self.sources_markdown[self.qa_list_pos])
+        markdown_stream = None
         try:
             url = f"{self.BASE_URL}/ask"
-            response = (await self._http_client.post(url,timeout=30,json={
-                'question':query
-            })).json()
-            if 'answer' not in response:
-                self.qas.update(str(response))
-            else:
-                answer = response['answer']
-                sources = response['sources']
-                self.add_qa(query,answer)
-                self.add_sources(sources)
-                self.panes_refresh()
+            streamed_answer_parts: list[str] = []
+            pending_text = ['']
+            stream_complete = [False]
+            markdown_stream = Markdown.get_stream(self.qas)
+            pump_task = asyncio.create_task(
+                self.pump_streamed_markdown(
+                    markdown_stream,
+                    streamed_answer_parts,
+                    pending_text,
+                    stream_complete,
+                )
+            )
+            async with self._http_client.stream('POST', url, timeout=30, json={
+                'question': query,
+                'streaming': True,
+            }) as response:
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+
+                    event = json.loads(line)
+                    event_type = event.get('type')
+
+                    if event_type == 'chunk':
+                        pending_text[0] += event.get('content', '')
+                        continue
+
+                    if event_type == 'final':
+                        stream_complete[0] = True
+                        await pump_task
+                        await markdown_stream.stop()
+                        answer_payload = event.get('answer', {})
+                        answer = answer_payload.get('answer', ''.join(streamed_answer_parts))
+                        sources = answer_payload.get('sources', [])
+                        self.update_streamed_answer(query, answer)
+                        self.source_list[self.qa_list_pos] = sources
+                        self.sources_markdown[self.qa_list_pos] = '\n\n'.join(
+                            '[@click=app.get_source_info("{}")]{}/[@click=]'.format(source.get('doc_path',''),source.get('doc_path',''))
+                            for source in sources
+                        )
+                        self.cache_sources(sources)
+                        self.panes_refresh()
+                        continue
+
+                    if event_type == 'error':
+                        stream_complete[0] = True
+                        await pump_task
+                        await markdown_stream.stop()
+                        error_message = event.get('content', 'Sorry, had trouble getting the answer to you. Try again later.')
+                        self.update_streamed_answer(query, error_message)
+                        break
         except:
+            if markdown_stream is not None:
+                await markdown_stream.stop()
             self.qas.update("Sorry, had trouble getting the answer to you. Try again later.")
         self.loading_indicator.display = False
 


### PR DESCRIPTION
This pull request introduces streaming support for the Kubebot TUI interface and backend, allowing answers to be streamed to the UI as they are generated, rather than waiting for a complete response. The main changes include implementing streaming endpoints and event types on the backend, updating the TUI to consume and render streamed responses, and refactoring the agent pipeline to support streaming.

**Backend streaming support:**

- Added new streaming event models (`StreamChunkEvent`, `StreamFinalEvent`, `StreamErrorEvent`) and included them in the backend models (`backend/models/StreamEvent.py`, `backend/models/__init__.py`). [[1]](diffhunk://#diff-3c81db1bf6b5b878aa467a847e82ec01dc4bba62d0fa8c6cbb7890a2c447a16aR1-R20) [[2]](diffhunk://#diff-8825f341dcb3666b912c0d9c56d2703959be919bdc99e55630a561fac81ee025R4)
- Implemented a streaming `/ask` endpoint in `backend/app.py` that streams responses as newline-delimited JSON events, handling both success and error cases. [[1]](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR1-R20) [[2]](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadL21-R61)
- Refactored the agent pipeline to support streaming: added `stream_agent_pipeline` and helper functions for streaming, chunk extraction, and final answer retrieval (`backend/services/chat.py`). [[1]](diffhunk://#diff-6f5842dc2f9645b2c95aa7d2384f20e6e76c11eea975eaaa51bd552a72d2c23bL133-R228) [[2]](diffhunk://#diff-6f5842dc2f9645b2c95aa7d2384f20e6e76c11eea975eaaa51bd552a72d2c23bL1-R7) [[3]](diffhunk://#diff-db8be68ad679cb00b5b6055a722e77941dc4afa229a3e42bfd96dc1d4fc53f6fL1-R1)

**TUI streaming integration:**

- Updated the TUI (`kubebot_tui.py`) to send streaming requests, process event streams, and incrementally reveal answers as they arrive, including error handling and source updates. [[1]](diffhunk://#diff-e54c8d80c6ed4b323a307813d096e6c29d2e611f7639f6b2815283fb133eeb0bR142-R169) [[2]](diffhunk://#diff-e54c8d80c6ed4b323a307813d096e6c29d2e611f7639f6b2815283fb133eeb0bR180-R240)
- Added streaming-related configuration and helper methods to control the reveal rate and manage streamed markdown updates in the TUI. [[1]](diffhunk://#diff-e54c8d80c6ed4b323a307813d096e6c29d2e611f7639f6b2815283fb133eeb0bR84-R85) [[2]](diffhunk://#diff-e54c8d80c6ed4b323a307813d096e6c29d2e611f7639f6b2815283fb133eeb0bR142-R169)

**API changes:**

- Extended the `UserQuery` model to include a `streaming` boolean flag to indicate whether streaming is requested.

These changes enable a more responsive user experience by delivering answers as they are generated, and provide robust error handling for streaming scenarios.